### PR TITLE
docs: Fix a few typos

### DIFF
--- a/firmware/code/Drivers/CMSIS/Include/core_cm3.h
+++ b/firmware/code/Drivers/CMSIS/Include/core_cm3.h
@@ -1428,7 +1428,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/firmware/code/Drivers/CMSIS/Include/core_cm4.h
+++ b/firmware/code/Drivers/CMSIS/Include/core_cm4.h
@@ -1602,7 +1602,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/firmware/code/Drivers/CMSIS/Include/core_cm7.h
+++ b/firmware/code/Drivers/CMSIS/Include/core_cm7.h
@@ -1810,7 +1810,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/firmware/code/Drivers/CMSIS/Include/core_sc300.h
+++ b/firmware/code/Drivers/CMSIS/Include/core_sc300.h
@@ -1410,7 +1410,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_dma.h
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_dma.h
@@ -166,7 +166,7 @@ typedef struct __DMA_HandleTypeDef
   */ 
 #define HAL_DMA_ERROR_NONE          (0x00000000U)    /*!< No error             */
 #define HAL_DMA_ERROR_TE            (0x00000001U)    /*!< Transfer error       */
-#define HAL_DMA_ERROR_NO_XFER       (0x00000004U)    /*!< no ongoin transfer   */
+#define HAL_DMA_ERROR_NO_XFER       (0x00000004U)    /*!< no ongoing transfer   */
 #define HAL_DMA_ERROR_TIMEOUT       (0x00000020U)    /*!< Timeout error        */
 #define HAL_DMA_ERROR_NOT_SUPPORTED (0x00000100U)    /*!< Not supported mode */     
 /**

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_i2c.h
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_i2c.h
@@ -102,7 +102,7 @@ typedef struct
   *             01 : Abort (Abort user request on going)\n
   *             10 : Timeout\n
   *             11 : Error\n
-  *          b5     IP initilisation status\n
+  *          b5     IP initialisation status\n
   *             0  : Reset (IP not initialized)\n
   *             1  : Init done (IP initialized and ready to use. HAL I2C Init function called)\n
   *          b4     (not used)\n

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_rcc_ex.h
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_rcc_ex.h
@@ -2003,14 +2003,14 @@ typedef struct
 #define __HAL_RCC_CRS_FREQ_ERROR_COUNTER_DISABLE() CLEAR_BIT(CRS->CR, CRS_CR_CEN)
 
 /**
-  * @brief  Enable the automatic hardware adjustement of TRIM bits.
+  * @brief  Enable the automatic hardware adjustment of TRIM bits.
   * @note   When the AUTOTRIMEN bit is set the CRS_CFGR register becomes write-protected.
   * @retval None
   */
 #define __HAL_RCC_CRS_AUTOMATIC_CALIB_ENABLE()     SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN)
 
 /**
-  * @brief  Disable the automatic hardware adjustement of TRIM bits.
+  * @brief  Disable the automatic hardware adjustment of TRIM bits.
   * @retval None
   */
 #define __HAL_RCC_CRS_AUTOMATIC_CALIB_DISABLE()    CLEAR_BIT(CRS->CR, CRS_CR_AUTOTRIMEN)

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart.h
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart.h
@@ -151,7 +151,7 @@ typedef struct
   *             01 : (Not Used)
   *             10 : Timeout
   *             11 : Error
-  *          b5     IP initilisation status
+  *          b5     IP initialisation status
   *             0  : Reset (IP not initialized)
   *             1  : Init done (IP not initialized. HAL UART Init function already called)
   *          b4-b3  (not used)
@@ -168,7 +168,7 @@ typedef struct
   *          RxState value coding follow below described bitmap :
   *          b7-b6  (not used)
   *             xx : Should be set to 00
-  *          b5     IP initilisation status
+  *          b5     IP initialisation status
   *             0  : Reset (IP not initialized)
   *             1  : Init done (IP not initialized)
   *          b4-b2  (not used)

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart_ex.h
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart_ex.h
@@ -63,7 +63,7 @@
   */
 typedef struct
 {
-  uint32_t WakeUpEvent;        /*!< Specifies which event will activat the Wakeup from Stop mode flag (WUF).
+  uint32_t WakeUpEvent;        /*!< Specifies which event will activate the Wakeup from Stop mode flag (WUF).
                                     This parameter can be a value of @ref UART_WakeUp_from_Stop_Selection.
                                     If set to UART_WAKEUP_ON_ADDRESS, the two other fields below must
                                     be filled up. */

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c
@@ -657,7 +657,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
   * @brief  Register callbacks
   * @param  hdma                 pointer to a DMA_HandleTypeDef structure that contains
   *                               the configuration information for the specified DMA Stream.
-  * @param  CallbackID           User Callback identifer
+  * @param  CallbackID           User Callback identifier
   *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
   * @param  pCallback            pointer to private callback function which has pointer to 
   *                               a DMA_HandleTypeDef structure as parameter.
@@ -710,7 +710,7 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
   * @brief  UnRegister callbacks
   * @param  hdma                 pointer to a DMA_HandleTypeDef structure that contains
   *                               the configuration information for the specified DMA Stream.
-  * @param  CallbackID           User Callback identifer
+  * @param  CallbackID           User Callback identifier
   *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
   * @retval HAL status
   */              

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_iwdg.c
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_iwdg.c
@@ -183,7 +183,7 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   assert_param(IS_IWDG_RELOAD(hiwdg->Init.Reload));
   assert_param(IS_IWDG_WINDOW(hiwdg->Init.Window));
 
-  /* Enable IWDG. LSI is turned on automaticaly */
+  /* Enable IWDG. LSI is turned on automatically */
   __HAL_IWDG_START(hiwdg);
 
   /* Enable write access to IWDG_PR, IWDG_RLR and IWDG_WINR registers by writing

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c
@@ -4708,7 +4708,7 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
   }
 
   /* Generate an update event to reload the Prescaler 
-     and the repetition counter(only for TIM1 and TIM8) value immediatly */
+     and the repetition counter(only for TIM1 and TIM8) value immediately */
   TIMx->EGR = TIM_EGR_UG;
 }
 

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart.c
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart.c
@@ -718,7 +718,7 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->gState = HAL_UART_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management*/
     tickstart = HAL_GetTick();
 
     huart->TxXferSize = Size;
@@ -803,7 +803,7 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->RxState = HAL_UART_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management*/
     tickstart = HAL_GetTick();
 
     huart->RxXferSize = Size;
@@ -2295,7 +2295,7 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
   huart->ErrorCode = HAL_UART_ERROR_NONE;
 
 #if !defined(STM32F030x6) && !defined(STM32F030x8)&& !defined(STM32F070xB)&& !defined(STM32F070x6)&& !defined(STM32F030xC)
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
   /* TEACK and REACK bits in ISR are checked only when available (not available on all F0 devices).

--- a/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart_ex.c
+++ b/firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart_ex.c
@@ -428,7 +428,7 @@ HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huar
   /* Enable the Peripheral */
   __HAL_UART_ENABLE(huart);
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
   /* Wait until REACK flag is set */
@@ -592,7 +592,7 @@ HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart)
   */
 static void UARTEx_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection)
 {
-  /* Check parmeters */
+  /* Check parameters */
   assert_param(IS_UART_WAKEUP_FROMSTOP_INSTANCE(huart->Instance));
   assert_param(IS_UART_ADDRESSLENGTH_DETECT(WakeUpSelection.AddressLength));
 

--- a/firmware/code/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c
+++ b/firmware/code/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c
@@ -170,7 +170,7 @@ USBD_StatusTypeDef  USBD_CtlContinueRx (USBD_HandleTypeDef  *pdev,
 }
 /**
 * @brief  USBD_CtlSendStatus
-*         send zero lzngth packet on the ctl pipe
+*         send zero length packet on the ctl pipe
 * @param  pdev: device instance
 * @retval status
 */
@@ -188,7 +188,7 @@ USBD_StatusTypeDef  USBD_CtlSendStatus (USBD_HandleTypeDef  *pdev)
 
 /**
 * @brief  USBD_CtlReceiveStatus
-*         receive zero lzngth packet on the ctl pipe
+*         receive zero length packet on the ctl pipe
 * @param  pdev: device instance
 * @retval status
 */

--- a/firmware/code/Src/usbd_cdc_if.c
+++ b/firmware/code/Src/usbd_cdc_if.c
@@ -282,7 +282,7 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
   *
   *         @note
   *         This function will block any OUT packet reception on USB endpoint
-  *         untill exiting this function. If you exit this function before transfer
+  *         until exiting this function. If you exit this function before transfer
   *         is complete on CDC interface (ie. using DMA controller) it will result
   *         in receiving more data while previous ones are still not sent.
   *

--- a/firmware/code/Src/usbd_conf.c
+++ b/firmware/code/Src/usbd_conf.c
@@ -703,7 +703,7 @@ USBD_StatusTypeDef USBD_LL_PrepareReceive(USBD_HandleTypeDef *pdev, uint8_t ep_a
 }
 
 /**
-  * @brief  Returns the last transfered packet size.
+  * @brief  Returns the last transferred packet size.
   * @param  pdev: Device handle
   * @param  ep_addr: Endpoint number
   * @retval Recived Data Size

--- a/firmware/code/Src/usbd_desc.c
+++ b/firmware/code/Src/usbd_desc.c
@@ -203,7 +203,7 @@ __ALIGN_BEGIN uint8_t USBD_FS_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
   #pragma data_alignment=4
 #endif /* defined ( __ICCARM__ ) */
 
-/** USB lang indentifier descriptor. */
+/** USB lang identifier descriptor. */
 __ALIGN_BEGIN uint8_t USBD_LangIDDesc[USB_LEN_LANGID_STR_DESC] __ALIGN_END =
 {
      USB_LEN_LANGID_STR_DESC,

--- a/resources/firmware_pmm/Drivers/CMSIS/Include/core_cm3.h
+++ b/resources/firmware_pmm/Drivers/CMSIS/Include/core_cm3.h
@@ -1428,7 +1428,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/resources/firmware_pmm/Drivers/CMSIS/Include/core_cm4.h
+++ b/resources/firmware_pmm/Drivers/CMSIS/Include/core_cm4.h
@@ -1602,7 +1602,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/resources/firmware_pmm/Drivers/CMSIS/Include/core_cm7.h
+++ b/resources/firmware_pmm/Drivers/CMSIS/Include/core_cm7.h
@@ -1810,7 +1810,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/resources/firmware_pmm/Drivers/CMSIS/Include/core_sc300.h
+++ b/resources/firmware_pmm/Drivers/CMSIS/Include/core_sc300.h
@@ -1410,7 +1410,7 @@ __STATIC_INLINE void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
   reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
   reg_value  =  (reg_value                                   |
                 ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8U)                      );              /* Insert write key and priority group */
   SCB->AIRCR =  reg_value;
 }
 

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_dma.h
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_dma.h
@@ -166,7 +166,7 @@ typedef struct __DMA_HandleTypeDef
   */ 
 #define HAL_DMA_ERROR_NONE          (0x00000000U)    /*!< No error             */
 #define HAL_DMA_ERROR_TE            (0x00000001U)    /*!< Transfer error       */
-#define HAL_DMA_ERROR_NO_XFER       (0x00000004U)    /*!< no ongoin transfer   */
+#define HAL_DMA_ERROR_NO_XFER       (0x00000004U)    /*!< no ongoing transfer   */
 #define HAL_DMA_ERROR_TIMEOUT       (0x00000020U)    /*!< Timeout error        */
 #define HAL_DMA_ERROR_NOT_SUPPORTED (0x00000100U)    /*!< Not supported mode */     
 /**

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_i2c.h
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_i2c.h
@@ -102,7 +102,7 @@ typedef struct
   *             01 : Abort (Abort user request on going)\n
   *             10 : Timeout\n
   *             11 : Error\n
-  *          b5     IP initilisation status\n
+  *          b5     IP initialisation status\n
   *             0  : Reset (IP not initialized)\n
   *             1  : Init done (IP initialized and ready to use. HAL I2C Init function called)\n
   *          b4     (not used)\n

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_rcc_ex.h
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_rcc_ex.h
@@ -2003,14 +2003,14 @@ typedef struct
 #define __HAL_RCC_CRS_FREQ_ERROR_COUNTER_DISABLE() CLEAR_BIT(CRS->CR, CRS_CR_CEN)
 
 /**
-  * @brief  Enable the automatic hardware adjustement of TRIM bits.
+  * @brief  Enable the automatic hardware adjustment of TRIM bits.
   * @note   When the AUTOTRIMEN bit is set the CRS_CFGR register becomes write-protected.
   * @retval None
   */
 #define __HAL_RCC_CRS_AUTOMATIC_CALIB_ENABLE()     SET_BIT(CRS->CR, CRS_CR_AUTOTRIMEN)
 
 /**
-  * @brief  Disable the automatic hardware adjustement of TRIM bits.
+  * @brief  Disable the automatic hardware adjustment of TRIM bits.
   * @retval None
   */
 #define __HAL_RCC_CRS_AUTOMATIC_CALIB_DISABLE()    CLEAR_BIT(CRS->CR, CRS_CR_AUTOTRIMEN)

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart.h
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart.h
@@ -151,7 +151,7 @@ typedef struct
   *             01 : (Not Used)
   *             10 : Timeout
   *             11 : Error
-  *          b5     IP initilisation status
+  *          b5     IP initialisation status
   *             0  : Reset (IP not initialized)
   *             1  : Init done (IP not initialized. HAL UART Init function already called)
   *          b4-b3  (not used)
@@ -168,7 +168,7 @@ typedef struct
   *          RxState value coding follow below described bitmap :
   *          b7-b6  (not used)
   *             xx : Should be set to 00
-  *          b5     IP initilisation status
+  *          b5     IP initialisation status
   *             0  : Reset (IP not initialized)
   *             1  : Init done (IP not initialized)
   *          b4-b2  (not used)

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart_ex.h
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart_ex.h
@@ -63,7 +63,7 @@
   */
 typedef struct
 {
-  uint32_t WakeUpEvent;        /*!< Specifies which event will activat the Wakeup from Stop mode flag (WUF).
+  uint32_t WakeUpEvent;        /*!< Specifies which event will activate the Wakeup from Stop mode flag (WUF).
                                     This parameter can be a value of @ref UART_WakeUp_from_Stop_Selection.
                                     If set to UART_WAKEUP_ON_ADDRESS, the two other fields below must
                                     be filled up. */

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c
@@ -657,7 +657,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
   * @brief  Register callbacks
   * @param  hdma                 pointer to a DMA_HandleTypeDef structure that contains
   *                               the configuration information for the specified DMA Stream.
-  * @param  CallbackID           User Callback identifer
+  * @param  CallbackID           User Callback identifier
   *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
   * @param  pCallback            pointer to private callback function which has pointer to 
   *                               a DMA_HandleTypeDef structure as parameter.
@@ -710,7 +710,7 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
   * @brief  UnRegister callbacks
   * @param  hdma                 pointer to a DMA_HandleTypeDef structure that contains
   *                               the configuration information for the specified DMA Stream.
-  * @param  CallbackID           User Callback identifer
+  * @param  CallbackID           User Callback identifier
   *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
   * @retval HAL status
   */              

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c
@@ -4708,7 +4708,7 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
   }
 
   /* Generate an update event to reload the Prescaler 
-     and the repetition counter(only for TIM1 and TIM8) value immediatly */
+     and the repetition counter(only for TIM1 and TIM8) value immediately */
   TIMx->EGR = TIM_EGR_UG;
 }
 

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart.c
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart.c
@@ -718,7 +718,7 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->gState = HAL_UART_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management*/
     tickstart = HAL_GetTick();
 
     huart->TxXferSize = Size;
@@ -803,7 +803,7 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->RxState = HAL_UART_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management*/
     tickstart = HAL_GetTick();
 
     huart->RxXferSize = Size;
@@ -2295,7 +2295,7 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
   huart->ErrorCode = HAL_UART_ERROR_NONE;
 
 #if !defined(STM32F030x6) && !defined(STM32F030x8)&& !defined(STM32F070xB)&& !defined(STM32F070x6)&& !defined(STM32F030xC)
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
   /* TEACK and REACK bits in ISR are checked only when available (not available on all F0 devices).

--- a/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart_ex.c
+++ b/resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart_ex.c
@@ -428,7 +428,7 @@ HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huar
   /* Enable the Peripheral */
   __HAL_UART_ENABLE(huart);
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
   /* Wait until REACK flag is set */
@@ -592,7 +592,7 @@ HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart)
   */
 static void UARTEx_Wakeup_AddressConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection)
 {
-  /* Check parmeters */
+  /* Check parameters */
   assert_param(IS_UART_WAKEUP_FROMSTOP_INSTANCE(huart->Instance));
   assert_param(IS_UART_ADDRESSLENGTH_DETECT(WakeUpSelection.AddressLength));
 


### PR DESCRIPTION
There are small typos in:
- firmware/code/Drivers/CMSIS/Include/core_cm3.h
- firmware/code/Drivers/CMSIS/Include/core_cm4.h
- firmware/code/Drivers/CMSIS/Include/core_cm7.h
- firmware/code/Drivers/CMSIS/Include/core_sc300.h
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_dma.h
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_i2c.h
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_rcc_ex.h
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart.h
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart_ex.h
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_iwdg.c
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart.c
- firmware/code/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart_ex.c
- firmware/code/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c
- firmware/code/Src/usbd_cdc_if.c
- firmware/code/Src/usbd_conf.c
- firmware/code/Src/usbd_desc.c
- resources/firmware_pmm/Drivers/CMSIS/Include/core_cm3.h
- resources/firmware_pmm/Drivers/CMSIS/Include/core_cm4.h
- resources/firmware_pmm/Drivers/CMSIS/Include/core_cm7.h
- resources/firmware_pmm/Drivers/CMSIS/Include/core_sc300.h
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_dma.h
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_i2c.h
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_rcc_ex.h
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart.h
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Inc/stm32f0xx_hal_uart_ex.h
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart.c
- resources/firmware_pmm/Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_uart_ex.c

Fixes:
- Should read `priority` rather than `priorty`.
- Should read `management` rather than `managment`.
- Should read `initialisation` rather than `initilisation`.
- Should read `identifier` rather than `identifer`.
- Should read `adjustment` rather than `adjustement`.
- Should read `parameters` rather than `parmeters`.
- Should read `ongoing` rather than `ongoin`.
- Should read `length` rather than `lzngth`.
- Should read `immediately` rather than `immediatly`.
- Should read `activate` rather than `activat`.
- Should read `until` rather than `untill`.
- Should read `transferred` rather than `transfered`.
- Should read `identifier` rather than `indentifier`.
- Should read `automatically` rather than `automaticaly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md